### PR TITLE
Add in the ability to use the shorthand CHAR

### DIFF
--- a/src/CreateTableParser.php
+++ b/src/CreateTableParser.php
@@ -24,7 +24,7 @@ class CreateTableParser extends BaseParser
 {
     public static $intTypes = ['INT', 'INTEGER', 'TINYINT', 'SMALLINT', 'MEDIUMINT', 'BIGINT', 'BIG INT', 'INT2', 'INT8'];
 
-    public static $textTypes = ['CHARACTER', 'VARCHAR', 'VARYING CHARACTER', 'NCHAR', 'NATIVE CHARACTER', 'NVARCHAR', 'TEXT', 'BLOB', 'BINARY'];
+    public static $textTypes = ['CHAR', 'CHARACTER', 'VARCHAR', 'VARYING CHARACTER', 'NCHAR', 'NATIVE CHARACTER', 'NVARCHAR', 'TEXT', 'BLOB', 'BINARY'];
 
     public static $numericTypes = ['NUMERIC', 'DECIMAL', 'BOOLEAN', 'DATE', 'DATETIME', 'TIMESTAMP'];
 


### PR DESCRIPTION
It's a valid definition and it's not in the list.  It will throw a `new Exception('Expecting type-name: '.$this->currentWindow());` if someone uses it.